### PR TITLE
core: implement abstract BaseConsulService interface. References #8

### DIFF
--- a/flask_consulate.py
+++ b/flask_consulate.py
@@ -142,68 +142,31 @@ class Consul(object):
         self.session.agent.service.register(**kwargs)
 
 
-class ConsulService(object):
+class BaseConsulService(object):
     """
-    Container for a consul service record
-    Example:
-
-        # Consul advertises a service called FOO that is reachable via two URIs:
-        # http://10.1.1.1:8001 and http://10.1.1.2:8002
-    cs = ConsulService("consul://tag.FOO.service")
-
-        # Set the DNS nameserver to the default docker0 bridge ip
-    cs = ConsulService("consul://tag.FOO.server", nameservers=['172.17.42.1'])
-
-        # returns a random choice from the DNS-advertised routes
-        # in our case, either http://10.1.1.1:8001 or http://10.1.1.2:8002
-    cs.base_url
-
-        # send an http-get to base_url+'/v1/status', re-resolving and
-        # re-retrying if that connection failed
-    cs.get('/v1/status')
-
-        #Subsequent http requests will now have the "X-Added" header
-    cs.session.headers.update({"X-Added": "Value"})
-    cs.post('/v1/status')
+    Interface to consul service. Subclasses must implement _resolve()
     """
-    def __init__(self, service_uri, nameservers=None):
+
+    def __init__(self, service_uri):
         """
         :param service_uri: string formatted service identifier
-            (consul://production.solr_service.consul)
-        :param nameservers: use custom nameservers
-        :type nameservers: list
+            (consul://production.my_service.consul)
         """
         assert service_uri.startswith('consul://'), "Invalid consul service URI"
         self.service_uri = service_uri
         self.service = service_uri.replace('consul://', '')
-        self.resolver = Resolver()
         self.session = requests.Session()
-        if nameservers is not None:
-            self.resolver.nameservers = nameservers
 
     def _resolve(self):
         """
-        Query the consul DNS server for the service IP and port
+        Query consul for the service. Must return a list of service urls.
         """
-        endpoints = {}
-        r = self.resolver.query(self.service, 'SRV')
-        for rec in r.response.additional:
-            name = rec.name.to_text()
-            addr = rec.items[0].address
-            endpoints[name] = {'addr': addr}
-        for rec in r.response.answer[0].items:
-            name = '.'.join(rec.target.labels)
-            endpoints[name]['port'] = rec.port
-        return [
-            "http://{ip}:{port}".format(
-                ip=v['addr'], port=v['port']
-            ) for v in endpoints.values()
-        ]
+        raise NotImplementedError()
 
     @property
     def base_url(self):
         """
-        get the next endpoint from self.endpoints
+        get the next endpoint from _resolve()
         """
         return self._resolve().pop()
 
@@ -240,3 +203,61 @@ class ConsulService(object):
 
     def head(self, endpoint, **kwargs):
         return self.request('HEAD', endpoint, **kwargs)
+
+
+class ConsulService(BaseConsulService):
+    """
+    Implementation of a consul service resolver using consul's DNS interface
+
+    Example:
+        # Consul advertises a service called FOO that is reachable via two URIs:
+        # http://10.1.1.1:8001 and http://10.1.1.2:8002
+    cs = ConsulService("consul://tag.FOO.service")
+
+        # Set the DNS nameserver to the default docker0 bridge ip
+    cs = ConsulService("consul://tag.FOO.server", nameservers=['172.17.42.1'])
+
+        # returns a random choice from the DNS-advertised routes
+        # in our case, either http://10.1.1.1:8001 or http://10.1.1.2:8002
+    cs.base_url
+
+        # send an http-get to base_url+'/v1/status', re-resolving and
+        # re-retrying if that connection failed
+    cs.get('/v1/status')
+
+        #Subsequent http requests will now have the "X-Added" header
+    cs.session.headers.update({"X-Added": "Value"})
+    cs.post('/v1/status')
+    """
+    def __init__(self, service_uri, nameservers=None):
+        """
+        :param service_uri: string formatted service identifier
+            (consul://production.solr_service.consul)
+        :param nameservers: use custom nameservers
+        :type nameservers: list
+        """
+        self.resolver = Resolver()
+
+        self.session = requests.Session()
+        if nameservers is not None:
+            self.resolver.nameservers = nameservers
+        super(ConsulService, self).__init__(service_uri)
+
+    def _resolve(self):
+        """
+        Query the consul DNS server for the service IP and port
+        """
+        endpoints = {}
+        r = self.resolver.query(self.service, 'SRV')
+        for rec in r.response.additional:
+            name = rec.name.to_text()
+            addr = rec.items[0].address
+            endpoints[name] = {'addr': addr}
+        for rec in r.response.answer[0].items:
+            name = '.'.join(rec.target.labels)
+            endpoints[name]['port'] = rec.port
+        return [
+            "http://{ip}:{port}".format(
+                ip=v['addr'], port=v['port']
+            ) for v in endpoints.values()
+        ]


### PR DESCRIPTION
Had this for a while living locally; this re-factor introduces an ABC for ConsulService. The API of the current DNS based implementation should not have changed at all.