### PR TITLE
travis: explicit pip install coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,5 @@
 omit = 
     */python?.?/*
     */site-packages/*
+    *.eggs/*
+    setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ python:
   - 3.6
   - 2.7
 install: 
-  - pip install coveralls
+  - pip install coverage coveralls
   - python setup.py install
-script: python setup.py test
+script: coverage run setup.py test
 after_success: coveralls
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.6
   - 2.7
 install: 
+  - pip install coveralls
   - python setup.py install
 script: python setup.py test
 after_success: coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 test = pytest
 
 [tool:pytest]
-addopts = -v -x --cov=flask_consulate --cov-report=term
+addopts = -v -x
 norecursedirs = build
 testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ TESTS_REQUIRE = [
     'mock',
     'six',
     'coveralls',
-    'pytest-cov',
+    'coverage',
     'pytest',
 ]
 


### PR DESCRIPTION
This shouldn't be necessary since we list this as a requirement in setup.py ... 