### PR TITLE
WIP: Update to support the API changes in consulate library. Fixes #22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache
 
 # Translations
 *.mo
@@ -107,6 +108,10 @@ ENV/
 
 # IntelliJ
 /out/
+
+# vscode
+.vscode
+.history
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/flask_consulate/consul.py
+++ b/flask_consulate/consul.py
@@ -4,7 +4,6 @@ import os
 import json
 
 import consulate
-import deprecation
 
 from six import iteritems
 
@@ -42,7 +41,6 @@ class Consul(object):
         self.max_tries = self.kwargs.get('max_tries', 3)
 
         self.consul = None
-
         self._session = None # for backward compatibility
 
         if app is not None:

--- a/flask_consulate/consul.py
+++ b/flask_consulate/consul.py
@@ -4,6 +4,7 @@ import os
 import json
 
 import consulate
+import deprecation
 
 from six import iteritems
 
@@ -42,8 +43,15 @@ class Consul(object):
 
         self.consul = None
 
+        self._session = None # for backward compatibility
+
         if app is not None:
             self.init_app(app)
+
+    @property
+    def session(self):
+        self.app.logger.warning("session field deprecated - please use .consul")
+        return self._session
 
     def init_app(self, app):
         self.app = app
@@ -57,6 +65,8 @@ class Consul(object):
         self.consul = self._create_consul(
             test_connection=self.kwargs.get('test_connection', False),
         )
+        # for backward compatibility
+        self._session = self.consul
 
     @with_retry_connections()
     def _create_consul(self, test_connection=False):
@@ -67,7 +77,7 @@ class Consul(object):
         :param test_connection: call .leader() to ensure that the connection
             is valid
         :type test_connection: bool
-        :return consulate.Session instance
+        :return consulate.Consul instance
         """
         consul = consulate.Consul(host=self.host, port=self.port)
         if test_connection:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ from flask import Flask
 
 from flask_consulate import Consul
 from flask_consulate.exceptions import ConsulConnectionError
+from consulate.exceptions import RequestError
 
 
 class TestFlaskConsulate(unittest.TestCase):
@@ -67,7 +68,7 @@ class TestFlaskConsulate(unittest.TestCase):
 
         app = self.create_app()
         self.assertRaises(
-            ConsulConnectionError,
+            RequestError,
             lambda: Consul(
                 app,
                 consul_host='consul.internal',
@@ -88,7 +89,7 @@ class TestFlaskConsulate(unittest.TestCase):
             body="localhost:8300",
         )
         app = self.create_app()
-        with mock.patch('consulate.Session') as mocked:
+        with mock.patch('consulate.Consul') as mocked:
             consul = Consul(app)
             consul.register_service()
             self.assertEqual(mocked.return_value.agent.service.register.call_count, 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,6 +63,11 @@ class TestFlaskConsulate(unittest.TestCase):
         )
         self.assertIsNotNone(consul)
 
+        self.assertIsNotNone(consul.consul)
+
+        # consul.session should equal consul.consul. Included for backwards compatability
+        self.assertEqual(consul.consul, consul.session)
+
         httpretty.disable()
         httpretty.reset()
 


### PR DESCRIPTION
As described. The main change is really that much of what used to be on the Session class is now on the root Consul class in the consulate package. Also, consulate now throws its own error if the agent is unavailable or there is some other issue making a request to it.
Marking WIP - since the consulate library hasn't actually released its changes yet.