### PR TITLE
use conditional log serialization

### DIFF
--- a/flask_consulate/consul.py
+++ b/flask_consulate/consul.py
@@ -98,15 +98,10 @@ class Consul(object):
             try:
                 self.app.config[k] = json.loads(v)
             except (TypeError, ValueError):
-                self.app.logger.warning("Couldn't de-serialize {} to json, using raw value".format(v))
+                self.app.logger.warning("Couldn't de-serialize %r to json, using raw value", v)
                 self.app.config[k] = v
 
-            msg = "Set {k}={v} from consul kv '{ns}'".format(
-                k=k,
-                v=v,
-                ns=namespace,
-            )
-            self.app.logger.debug(msg)
+            self.app.logger.debug("Set %s=%s from consul kv %r", k, v, namespace)
 
     @with_retry_connections()
     def register_service(self, **kwargs):


### PR DESCRIPTION
Uses the conditional serialization log style [recommended by the howto](https://docs.python.org/3/howto/logging.html#logging-variable-data) to avoid always serializing large data structures even when log level is not at debug.

#24 