### PR TITLE
require six as install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,13 @@ INSTALL_REQUIRES = [
     'consulate',
     'Flask',
     'requests>=2.7.0',
+    'six',
     dnspython,
 ]
 
 TESTS_REQUIRE = [
     'httpretty',
     'mock',
-    'six',
     'coveralls',
     'coverage',
     'pytest',


### PR DESCRIPTION
Aims to fix #26 

Should be an extremely low-impact change.

Is there any chance of getting a new versioned release pushed to PyPI?

Thanks!